### PR TITLE
Add Standard_D3_v2

### DIFF
--- a/createUiDefinition.json
+++ b/createUiDefinition.json
@@ -190,7 +190,8 @@
             "publicIpDNS": "[steps('instanceDetails').domainSpec.domainNameLabel]",
             "publicIpName": "[steps('instanceDetails').domainSpec.name]",
             "publicIpNewOrExisting": "[steps('instanceDetails').domainSpec.newOrExistingOrNone]",
-            "publicIpRG": "[steps('instanceDetails').domainSpec.resourceGroup]"
+            "publicIpRG": "[steps('instanceDetails').domainSpec.resourceGroup]",
+            "location": "[location()]"
         }
     }
 }

--- a/createUiDefinition.json
+++ b/createUiDefinition.json
@@ -69,6 +69,7 @@
                         "constraints": {
                             "allowedSizes": [
                                 "Standard_D3",
+                                "Standard_D3_v2",
                                 "Standard_A3",
                                 "Standard_G3",
                                 "Standard_GS3"
@@ -190,8 +191,7 @@
             "publicIpDNS": "[steps('instanceDetails').domainSpec.domainNameLabel]",
             "publicIpName": "[steps('instanceDetails').domainSpec.name]",
             "publicIpNewOrExisting": "[steps('instanceDetails').domainSpec.newOrExistingOrNone]",
-            "publicIpRG": "[steps('instanceDetails').domainSpec.resourceGroup]",
-            "location": "[location()]"
+            "publicIpRG": "[steps('instanceDetails').domainSpec.resourceGroup]"
         }
     }
 }


### PR DESCRIPTION
If you're happy to allow users to deploy on the D3 V2 instances, then this change includes that in the allowedSizes
